### PR TITLE
Introduce associated AudioSession

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -134,6 +134,13 @@ This default audio session is represented as an {{AudioSession}} object that is 
 
 # Extensions to the `Navigator` interface # {#extensions-to-navigator}
 
+Each {{Window}} has an <dfn>associated AudioSession</dfn>, which is an {{AudioSession}} object.
+It represents the default audio session that is used by the user agent to automatically set up the audio session parameters.
+The user agent will request or abandon audio focus when audio session [=audio session/elements=] start or finish playing.
+Upon creation of the {{Window}} object, its [=associated AudioSession=] MUST be set to a newly created {{AudioSession}} object with the {{Window}} object's [=relevant realm=].
+
+The [=associated AudioSession=] list of [=audio session/elements=] is updated dynamically as audio sources and sinks of the {{Window}} object  are created or removed.
+
 <pre class="idl">
 [Exposed=Window]
 partial interface Navigator {

--- a/index.bs
+++ b/index.bs
@@ -139,7 +139,7 @@ It represents the default audio session that is used by the user agent to automa
 The user agent will request or abandon audio focus when audio session [=audio session/elements=] start or finish playing.
 Upon creation of the {{Window}} object, its [=associated AudioSession=] MUST be set to a newly created {{AudioSession}} object with the {{Window}} object's [=relevant realm=].
 
-The [=associated AudioSession=] list of [=audio session/elements=] is updated dynamically as audio sources and sinks of the {{Window}} object  are created or removed.
+The [=associated AudioSession=] list of [=audio session/elements=] is updated dynamically as audio sources and sinks of the {{Window}} object are created or removed.
 
 <pre class="idl">
 [Exposed=Window]


### PR DESCRIPTION
We introduce the 1-1 mapping between Window and navigator.audioSession.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/audio-session/pull/32.html" title="Last updated on Oct 22, 2024, 1:42 PM UTC (1466c1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audio-session/32/66d2ba3...youennf:1466c1f.html" title="Last updated on Oct 22, 2024, 1:42 PM UTC (1466c1f)">Diff</a>