### PR TITLE
Make transient-solo an exclusive type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -133,7 +133,7 @@ In the API, these are represented by the {{AudioSessionType}} enum:
   };
 </pre>
 
-An {{AudioSessionType}} is an <dfn>exclusive type</dfn> if it is {{AudioSessionType/playback}} or {{AudioSessionType/play-and-record}}.
+An {{AudioSessionType}} is an <dfn>exclusive type</dfn> if it is {{AudioSessionType/playback}}, {{AudioSessionType/play-and-record}} or {{AudioSessionType/transient-solo}}.
 
 ## Audio session states ## {#audio-session-states}
 


### PR DESCRIPTION
Fixes https://github.com/w3c/audio-session/issues/35


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/audio-session/pull/36.html" title="Last updated on Oct 28, 2024, 11:22 AM UTC (3baf336)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audio-session/36/f62ea81...youennf:3baf336.html" title="Last updated on Oct 28, 2024, 11:22 AM UTC (3baf336)">Diff</a>