### PR TITLE
Automate publication of the ED to /TR

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -30,3 +30,7 @@ jobs:
         uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://github.com/w3c/media-wg/issues/27
+          W3C_BUILD_OVERRIDE: |
+            status: WD

--- a/index.bs
+++ b/index.bs
@@ -6,6 +6,7 @@ Status: w3c/ED
 Group: mediawg
 Repository: w3c/audio-session
 URL: https://w3c.github.io/audio-session/
+TR: https://www.w3.org/TR/audio-session/
 Editor: Youenn Fablet, Apple https://www.apple.com/, youenn@apple.com, w3cid 96458
 Editor: Alastor Wu, Mozilla https://www.mozilla.org, alwu@mozilla.com, w3cid 92198
 Abstract: This API defines an API surface for controlling how audio is rendered and interacts with other audio playing applications.

--- a/index.bs
+++ b/index.bs
@@ -8,7 +8,7 @@ Repository: w3c/audio-session
 URL: https://w3c.github.io/audio-session/
 Editor: Youenn Fablet, Apple https://www.apple.com/, youenn@apple.com, w3cid 96458
 Editor: Alastor Wu, Mozilla https://www.mozilla.org, alwu@mozilla.com, w3cid 92198
-Abstract: This API defines an API surface for controlling how audio is rendered and interacts with other audio playing applications
+Abstract: This API defines an API surface for controlling how audio is rendered and interacts with other audio playing applications.
 Markup Shorthands: css no, markdown yes
 </pre>
 


### PR DESCRIPTION
This adds the missing job parameters to enable automatic publication of the Audio Session Editor's Draft as a Working Draft under https://www.w3.org/TR/

I added the token needed by Echidna for authentication as a secret in the repository.

Minor editorial update: the abstract did not have a final `.`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audio-session/pull/37.html" title="Last updated on Nov 8, 2024, 10:58 AM UTC (f6c9a59)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audio-session/37/a6ba03a...f6c9a59.html" title="Last updated on Nov 8, 2024, 10:58 AM UTC (f6c9a59)">Diff</a>