### PR TITLE
Update CONTRIBUTING.md to match template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,24 @@
 # Contributing
 
-Contributions to this repository are intended to become part of
-Recommendation-track documents governed by the
-[W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy-20200915/) and
-[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).
-To contribute, you must either participate in the relevant W3C Working Group or
-make a non-member patent licensing commitment.
+Contributions to this repository are intended to become part of Recommendation-track documents governed by the
+[W3C Patent Policy](https://www.w3.org/policies/patent-policy/) and
+[Software and Document License](https://www.w3.org/copyright/software-license/). To make substantive contributions to specifications, you must either participate
+in the relevant W3C Working Group or make a non-member patent licensing commitment.
 
-If you are not the sole contributor to a contribution (pull request), please
-identify all contributors in the pull request's body or in subsequent comments.
+If you are not the sole contributor to a contribution (pull request), please identify all 
+contributors in the pull request comment.
 
-To add a contributor (other than yourself, that's automatic), mark them one per
-line as follows:
+To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
 
- ```
- +@github_username
- ```
+```
++@github_username
+```
 
 If you added a contributor by mistake, you can remove them in a comment with:
 
- ```
- -@github_username
- ```
+```
+-@github_username
+```
 
-If you are making a pull request on behalf of someone else but you had no part
-in designing the feature, you can remove yourself with the above syntax.
+If you are making a pull request on behalf of someone else but you had no part in designing the 
+feature, you can remove yourself with the above syntax.


### PR DESCRIPTION
This refreshes links to the Patent Policy and license, and scopes participation requirement and licensing commitment to substantive contributions.

Updated text matches the template at https://github.com/w3c/ash-nazg/blob/master/templates/WG-CONTRIBUTING-SW.md

See also: https://github.com/w3c/webcodecs/pull/902
